### PR TITLE
Switch Unicode::Normalize to XSLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+Normalize.bs
+Normalize.c
+Normalize.o
+blib/
+pm_to_blib
+unfcan.h
+unfcmb.h
+unfcmp.h
+unfcpt.h
+unfexc.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: "perl"
+sudo: false
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "dev"
+  - "blead"
+
+# slows down already cached versions by 3 (33s => 1m45s)
+# (i.e. cache download: 9s, setup: 45s-130s)
+# but speeds up building the non-cached versions (5.24-*) by 2 (3m50s => 1m45s)
+# overall: 25min => 35min, so disable the perl cache
+#cache:
+#  directories:
+#    - /home/travis/perl5/perlbrew/
+
+# blead and 5.6 stumble over YAML and more missing dependencies
+# for Devel::Cover::Report::Coveralls
+# cpanm does not do 5.6
+before_install:
+  - mkdir /home/travis/bin || true
+  - ln -s `which true` /home/travis/bin/cpansign
+  - eval $(curl https://travis-perl.github.io/init) --auto
+install:
+  - export AUTOMATED_TESTING=1 HARNESS_TIMER=1 AUTHOR_TESTING=0 RELEASE_TESTING=0
+  #- cpan-install --deps       # installs prereqs, including recommends
+  #- cpan-install Test::LeakTrace
+  - cpan-install --coverage   # installs converage prereqs, if enabled
+
+before_script:
+  - coverage-setup
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+matrix:
+  fast_finish: true
+  include:
+  allow_failures:
+    - env: COVERAGE=1 AUTHOR_TESTING=1
+    - perl: "blead"
+
+# Hack to not run on tag pushes:
+branches:
+  except:
+  - /^v?[0-9]+\.[0-9]+/

--- a/Normalize.pm
+++ b/Normalize.pm
@@ -56,9 +56,9 @@ require Exporter;
 
 ##### The above part is common to XS and PP #####
 
-our @ISA = qw(Exporter DynaLoader);
-require DynaLoader;
-bootstrap Unicode::Normalize $VERSION;
+our @ISA = qw(Exporter);
+use XSLoader ();
+XSLoader::load( 'Unicode::Normalize', $VERSION );
 
 ##### The below part is common to XS and PP #####
 


### PR DESCRIPTION
p5p has recently switched all CORE modules to XSLoader
for performance reasons during the 5.27 development cycle.

Note, XSLoader is a problem for Perl versions earlier than 5.6,
which at this point can get alternate support, as mentioned
in the upstream case.

Upstream-Case: RT #132080
Upstream-URL: https://rt.perl.org/SelfService/Display.html?id=132080